### PR TITLE
Feature/auto push

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ dart pub global activate --source=path <path to this package>
 - 🤖 Leverages various AI models to analyze your code changes and generate meaningful commit messages
 - 🔄 Follows conventional commit format with emojis: `<emoji> <type>: <description>`
 - 📋 Pre-fills the Git commit editor for easy review and modification
+- 🚀️ Supports automatic pushing of commits to the remote repository
 - 🔍 Code analysis to understand staged changes and get suggestions for improvements
 - 🎫 Supports ticket number prefixing for commit messages
 - 🧩 Choose specific model variants (gpt-4o, claude-3-opus, etc.)
@@ -58,6 +59,11 @@ gw commit --model openai --model-variant gpt-4o
 # Add a ticket number prefix to your commit message
 gitwhisper commit --prefix "JIRA-123"
 gw commit --prefix "JIRA-123"
+
+# Automatically push the commit to the remote repository
+gitwhisper commit --auto-push
+gw commit --auto-push
+gw commit -a # shorthand for --auto-push
 
 # Analyze your changes (staged/unstaged) with AI
 gitwhisper analyze

--- a/lib/src/commands/commit_command.dart
+++ b/lib/src/commands/commit_command.dart
@@ -59,6 +59,12 @@ class CommitCommand extends Command<int> {
         abbr: 'v',
         help: 'Specific variant of the AI model to use',
         valueHelp: 'gpt-4o, claude-3-opus, gemini-pro, etc.',
+      )
+      ..addFlag(
+        'auto-push',
+        abbr: 'a',
+        help: 'Automatically push the commit to the remote repository',
+        defaultsTo: false,
       );
   }
 
@@ -164,7 +170,10 @@ class CommitCommand extends Command<int> {
         ..info('');
 
       try {
-        await GitUtils.runGitCommit(commitMessage);
+        await GitUtils.runGitCommit(
+          message: commitMessage,
+          autoPush: argResults?['auto-push'] as bool,
+        );
       } catch (e) {
         _logger.err('Error setting commit message: $e');
         return ExitCode.software.code;

--- a/lib/src/git_utils.dart
+++ b/lib/src/git_utils.dart
@@ -73,10 +73,11 @@ class GitUtils {
         final remote = (remoteName.stdout as String).trim();
         $logger
           ..info('')
-          ..info('Are you sure you want to push to $branch on $remote? (y/n)')
-          ..info('');
+          ..info('Are you sure you want to push to $branch on $remote? (y/n)\n')
+
 
         final confirmation = stdin.readLineSync();
+
 
         if (confirmation == null || confirmation.toLowerCase() != 'y') {
           $logger.info('Push cancelled‼️.');

--- a/lib/src/git_utils.dart
+++ b/lib/src/git_utils.dart
@@ -39,13 +39,32 @@ class GitUtils {
   }
 
   /// Run git commit
-  static Future<void> runGitCommit(String message) async {
+  static Future<void> runGitCommit(
+      {required String message, bool autoPush = false}) async {
     final args = ['commit', '-m', message];
     final result = await Process.run('git', args);
     if (result.exitCode != 0) {
       throw Exception('Error during git commit: ${result.stderr}');
     } else {
       $logger.success('Commit successful! 🎉');
+
+      /// Push the commit if autoPush is true
+      if (autoPush) {
+        $logger
+          ..info('')
+          ..info('Pushing changes to remote repository...')
+          ..info('')
+          ..info('---------------------------------')
+          ..info('Current Directory: ${Directory.current.path}')
+          ..info('---------------------------------');
+
+        final pushResult = await Process.run('git', ['push']);
+        if (pushResult.exitCode != 0) {
+          throw Exception('Error during git push: ${pushResult.stderr}');
+        } else {
+          $logger.success('Push successful! 🎉');
+        }
+      }
     }
   }
 

--- a/lib/src/git_utils.dart
+++ b/lib/src/git_utils.dart
@@ -55,9 +55,38 @@ class GitUtils {
           ..info('Pushing changes to remote repository...')
           ..info('')
           ..info('---------------------------------')
+          ..info('')
           ..info('Current Directory: ${Directory.current.path}')
+          ..info('')
           ..info('---------------------------------');
 
+        /// Prompt user to confirm push on [branchName] on [remoteName]
+        final branchName =
+            await Process.run('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
+        final remoteName =
+            await Process.run('git', ['config', '--get', 'remote.origin.url']);
+        if (branchName.exitCode != 0 || remoteName.exitCode != 0) {
+          throw Exception(
+              'Error getting branch or remote name: ${branchName.stderr}');
+        }
+        final branch = (branchName.stdout as String).trim();
+        final remote = (remoteName.stdout as String).trim();
+        $logger
+          ..info('')
+          ..info('Are you sure you want to push to $branch on $remote? (y/n)')
+          ..info('');
+
+        final confirmation = stdin.readLineSync();
+
+        if (confirmation == null || confirmation.toLowerCase() != 'y') {
+          $logger.info('Push cancelled‼️.');
+          return;
+        }
+        $logger
+          ..info('Pushing changes to remote repository...')
+          ..info('');
+
+        /// Run the git push command
         final pushResult = await Process.run('git', ['push']);
         if (pushResult.exitCode != 0) {
           throw Exception('Error during git push: ${pushResult.stderr}');

--- a/lib/src/git_utils.dart
+++ b/lib/src/git_utils.dart
@@ -73,11 +73,10 @@ class GitUtils {
         final remote = (remoteName.stdout as String).trim();
         $logger
           ..info('')
-          ..info('Are you sure you want to push to $branch on $remote? (y/n)\n')
-
+          ..info(
+              'Are you sure you want to push to $branch on $remote? (y/n)\n');
 
         final confirmation = stdin.readLineSync();
-
 
         if (confirmation == null || confirmation.toLowerCase() != 'y') {
           $logger.info('Push cancelled‼️.');


### PR DESCRIPTION
## Description

This PR adds support for an `--auto-push` flag (and corresponding `autoPush` config option) so that after `git commit`, changes are automatically pushed to the remote. It streamlines the workflow by removing the need to run `git push` manually.

**What’s new:**
- New `--auto-push` CLI flag and `autoPush` boolean in the Dart API
- Runs `git push` automatically when enabled
- Updates docs (README and examples) to show how to enable/configure auto-push


## Type of Change


- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
