### PR TITLE
feat: Add large file detection and auto file-by-file processing

### DIFF
--- a/lib/src/commands/set_defaults_command.dart
+++ b/lib/src/commands/set_defaults_command.dart
@@ -76,6 +76,12 @@ class SetDefaultsCommand extends Command<int> {
         help: 'Maximum diff size (in characters) before prompting for '
             'interactive staging (default: 50000)',
         valueHelp: '50000',
+      )
+      ..addOption(
+        'max-file-size',
+        help: 'Maximum file size (in MB) before warning about large files '
+            '(default: 10)',
+        valueHelp: '10',
       );
   }
 
@@ -238,6 +244,21 @@ class SetDefaultsCommand extends Command<int> {
       configManager.setMaxDiffSize(maxDiffSize);
       await configManager.save();
       _logger.success('Max diff size set to $maxDiffSize characters.');
+    }
+
+    // Handle max file size setting
+    final maxFileSizeStr = argResults?['max-file-size'] as String?;
+    if (maxFileSizeStr != null) {
+      final maxFileSizeMB = int.tryParse(maxFileSizeStr);
+      if (maxFileSizeMB == null || maxFileSizeMB <= 0) {
+        _logger.err(
+            'Invalid max-file-size value. Must be a positive integer (MB).');
+        return ExitCode.usage.code;
+      }
+      // Convert MB to bytes
+      configManager.setMaxFileSize(maxFileSizeMB * 1024 * 1024);
+      await configManager.save();
+      _logger.success('Max file size set to $maxFileSizeMB MB.');
     }
 
     if (modelVariant == null &&

--- a/lib/src/config_manager.dart
+++ b/lib/src/config_manager.dart
@@ -177,6 +177,16 @@ class ConfigManager {
     return _config['max_diff_size'] as int? ?? 50000;
   }
 
+  /// Set max file size for large file warning (in bytes)
+  void setMaxFileSize(int bytes) {
+    _config['max_file_size'] = bytes;
+  }
+
+  /// Get max file size for large file warning (default: 10MB = 10485760 bytes)
+  int getMaxFileSize() {
+    return _config['max_file_size'] as int? ?? 10485760;
+  }
+
   /// Check if user has accepted the free model disclaimer
   bool hasAcceptedFreeDisclaimer() {
     return _config['free_disclaimer_accepted'] as bool? ?? false;


### PR DESCRIPTION
## Summary
- **Large file detection**: Automatically detects files >10MB (configurable) before commit. Shows warning for files already in remote history, blocks and prompts for new large files with option to add to .gitignore
- **Auto file-by-file processing**: When diff exceeds max size, automatically processes file-by-file without user prompts, generating summaries for each file then combining for final commit message
- **New config option**: `--max-file-size` to configure the threshold in MB

## Test plan
- [ ] Create a 15MB file, stage it, run `gw commit` - should warn and offer to add to .gitignore
- [ ] Make changes to 5+ files exceeding max diff size, run `gw commit` - should see file-by-file processing logs
- [ ] Test `gw set-defaults --max-file-size 50` to change threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)